### PR TITLE
Fix deprecation warning for .Site.Social param (hugo 0.124)

### DIFF
--- a/layouts/partials/social-share.html
+++ b/layouts/partials/social-share.html
@@ -3,8 +3,13 @@
 
 {{ $facebook_href := printf "https://www.facebook.com/sharer.php?u=%s" $url }}
 {{ $twitter_href := printf "https://twitter.com/intent/tweet?url=%s&text=%s" $url $title }}
-{{ with site.Social.twitter }}
-  {{ $twitter_href = printf "%s&via=%s" $twitter_href . }}
+{{/* Looking for twitter in the registered services */}}
+{{ with site.Params.ananke_socials }}
+  {{ range $service := . }}
+    {{ if eq .name "twitter" }}
+      {{ $twitter_href = printf "%s&via=%s" $twitter_href . }}
+    {{ end }}
+  {{ end }}
 {{ end }}
 {{ $linkedin_href := printf "https://www.linkedin.com/shareArticle?mini=true&url=%s&title=%s" $url $title }}
 {{ $hrefs := dict "facebook" $facebook_href "twitter" $twitter_href "linkedin" $linkedin_href }}


### PR DESCRIPTION
This PR fixes a deprecation warning emitted by hugo:

```
INFO  deprecated: .Site.Social was deprecated in Hugo v0.124.0 and will be removed in a future release. Use .Site.Params instead.
```