### PR TITLE
theme(fix): deprecated: .Site.Social

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ params:
     label: Facebook
     follow: false
   - name: twitter
+    username: theNewDynamic
     url: https://twitter.com/theNewDynamic
     label: TND Twitter
 ```

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -39,3 +39,4 @@ enableRobotsTXT = true
 [[params.ananke_socials]]
 name = "twitter"
 url = "https://twitter.com/GoHugoIO"
+username = "GoHugoIO"

--- a/layouts/partials/social-share.html
+++ b/layouts/partials/social-share.html
@@ -3,8 +3,10 @@
 
 {{ $facebook_href := printf "https://www.facebook.com/sharer.php?u=%s" $url }}
 {{ $twitter_href := printf "https://twitter.com/intent/tweet?url=%s&text=%s" $url $title }}
-{{ with site.Social.twitter }}
-  {{ $twitter_href = printf "%s&via=%s" $twitter_href . }}
+
+{{ $twitterSetup := first 1 (where site.Params.ananke_socials "name" "twitter") }}
+{{ with index $twitterSetup 0 }}
+  {{ $twitter_href = printf "%s&via=%s" $twitter_href .username }}
 {{ end }}
 {{ $linkedin_href := printf "https://www.linkedin.com/shareArticle?mini=true&url=%s&title=%s" $url $title }}
 {{ $hrefs := dict "facebook" $facebook_href "twitter" $twitter_href "linkedin" $linkedin_href }}


### PR DESCRIPTION
Quick fix for the error "deprecated: .Site.Social" in #711 

This will not make it into master in this current format. Keep an eye on the issue to find out when we have a proper solution. 