### PR TITLE
fix: support images array for featured image

### DIFF
--- a/layouts/_partials/func/GetFeaturedImage.html
+++ b/layouts/_partials/func/GetFeaturedImage.html
@@ -5,11 +5,14 @@
 
 	If a featured_image was set in the page's front matter, then that will be used.
 
+	If no featured_image was set, this will use the first image from the page's
+	images front matter array.
+
 	If not set, this will search page resources to find an image that contains the word
 	"cover", and if found, returns the path to that resource.
 
-	If no featured_image was set, and there's no "cover" image in page resources, then
-	this partial returns an empty string (which evaluates to false).
+	If no featured_image or images value was set, and there's no "cover" image in page
+	resources, then this partial returns an empty string (which evaluates to false).
 
 	@return RelPermalink to featured image, or an empty string if not found.
 
@@ -27,11 +30,24 @@
   {{ with $.Resources.GetMatch . }}
     {{ $linkToCover = .RelPermalink }}
   {{ end }}
-{{/* Find the first image with 'cover' in the name in this page bundle. */}}
 {{ else }}
-  {{ with .Resources.ByType "image" }}
-    {{ with .GetMatch (fmt.Printf "**{%s}*" $matches) }}
-      {{ $linkToCover = .RelPermalink }}
+  {{/* Use the first value from the images front matter array if present. */}}
+  {{ with .Params.images }}
+    {{ range first 1 . }}
+      {{ with . }}
+        {{ $linkToCover = strings.Trim . "/" | urls.AbsURL }}
+        {{/* If we find a Page Resource matching the exact value, we use it instead. */}}
+        {{ with $.Resources.GetMatch . }}
+          {{ $linkToCover = .RelPermalink }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{/* Find the first image with 'cover' in the name in this page bundle. */}}
+  {{ else }}
+    {{ with .Resources.ByType "image" }}
+      {{ with .GetMatch (fmt.Printf "**{%s}*" $matches) }}
+        {{ $linkToCover = .RelPermalink }}
+      {{ end }}
     {{ end }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
## Summary

* Adds `Params.images` fallback support to `layouts/_partials/func/GetFeaturedImage.html`.
* Keeps `featured_image` as the primary source for backwards compatibility.
* Uses the first value from `images` when `featured_image` is not set, matching Hugo's embedded-template image metadata convention.
* Preserves existing Page Resource resolution for exact matches and the existing `cover`/`feature` page-resource fallback.

## Issue

Closes #77.

## Documentation

Documentation PR: gohugo-ananke/documentation#10

## Verification

* Inspected issue #77 and its comments.
* Checked repository contribution guidance in `CONTRIBUTING.md`.
* Reviewed the existing featured image helper before changing it.
* No local Hugo build was run because the execution container cannot resolve `github.com` for cloning dependencies.

## Notes

The lookup order after this change is:

1. `featured_image`
2. First value in `images`
3. First page resource containing `feature` or `cover` in its path