### PR TITLE
fix: define summary image dimensions

### DIFF
--- a/layouts/summary-with-image.html
+++ b/layouts/summary-with-image.html
@@ -6,7 +6,7 @@
           {{/* Trimming the slash and adding absURL make sure the image works no matter collections.Where our site lives */}}
         <div class="{{ compare.Conditional (compare.Eq $.Site.Language.Direction "rtl") "pl3-ns" "pr3-ns" }} mb4 mb0-ns w-100 w-40-ns">
           <a href="{{.RelPermalink}}" class="db grow">
-            <img src="{{ $featured_image }}" class="img" alt="image from {{ .Title }}">
+            <img src="{{ $featured_image }}" class="img" alt="image from {{ .Title }}" width="600" height="400">
           </a>
         </div>
       {{ end }}


### PR DESCRIPTION
## Summary

* adds fallback `width` and `height` attributes to homepage/list summary featured images
* keeps existing template structure and classes unchanged
* documents the related summary image behaviour in gohugo-ananke/documentation#12

## Motivation

Issue #366 reports an SVG featured image that appears correctly on the article page but renders blank on the home page summary. The issue discussion notes that the likely cause is missing explicit image dimensions.

## Changes

* `layouts/summary-with-image.html`
  * adds `width="600"` and `height="400"` to the summary image element

## Related

Closes #366
Refs gohugo-ananke/documentation#12

## Verification

* Compared `development...fix/issue-366-homepage-image-dimensions`; the theme PR changes only `layouts/summary-with-image.html`.
* Reviewed the issue and maintainer comment before changing the template.
* Not run locally: local network access to clone GitHub repositories is unavailable in this environment, so validation was limited to repository inspection and connector-level diffs.

## Notes

The change intentionally avoids changing CSS or image lookup behaviour. It only provides a stable fallback display size for summary images that do not expose useful intrinsic dimensions.