### PR TITLE
feat: add since shortcode for release badges

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -34,6 +34,9 @@ other = "An email address is required."
 [send]
 other = "Send"
 
+[since]
+other = "since"
+
 [taxonomyPageList]
 other = "Below you will find pages that utilize the taxonomy term “{{ .Title }}”"
 

--- a/layouts/_shortcodes/since.html
+++ b/layouts/_shortcodes/since.html
@@ -1,0 +1,46 @@
+{{- /*
+  since shortcode
+
+  Renders a small badge marking the release a feature was introduced in.
+
+  The version is taken from, in order of precedence:
+    - the first positional argument:  since "2.17.0"
+    - the named "version" argument:   since version="2.17.0"
+    - the page's "since" front matter: since = "2.17.0"
+
+  Configuration (all optional, not set by default):
+    - params.ananke.shortcodes.since.repo_url
+        A printf format string receiving the version (e.g. ".../tag/v%s").
+        When unset the badge renders as plain text with no link.
+    - params.ananke.shortcodes.since.target
+        Link target. Defaults to "_blank". Set to a custom value (e.g. "_top")
+        or to false to open in the same window.
+*/ -}}
+{{- $version := or (.Get 0) (.Get "version") .Page.Params.since -}}
+{{- with $version -}}
+  {{- $repoURL := "" -}}
+  {{- $target := "_blank" -}}
+  {{- with site.Params.ananke -}}
+    {{- with .shortcodes -}}
+      {{- with .since -}}
+        {{- with .repo_url }}{{ $repoURL = . }}{{ end -}}
+        {{- if isset . "target" }}{{ $target = .target }}{{ end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $label := printf "%s %s" (T "since") . -}}
+  {{- if $repoURL -}}
+    {{- $url := printf $repoURL . -}}
+    {{- $rel := "" -}}
+    {{- if and $target (ne $target "_self") }}{{ $rel = "noopener" }}{{ end -}}
+    <a class="f6 link dim br2 ba bw1 ph3 pv2 mb2 dib navy" href="{{ $url }}"
+      {{- with $target }} target="{{ . }}"{{ end -}}
+      {{- with $rel }} rel="{{ . }}"{{ end }}>
+      {{ $label }}
+    </a>
+  {{- else -}}
+    <span class="f6 br2 ba bw1 ph3 pv2 mb2 dib navy">{{ $label }}</span>
+  {{- end -}}
+{{- else -}}
+  {{- warnf "[ananke] the 'since' shortcode in %q needs a version argument or a 'since' front matter value" .Page.File.Path -}}
+{{- end -}}

--- a/layouts/_shortcodes/since.html
+++ b/layouts/_shortcodes/since.html
@@ -16,7 +16,13 @@
         Link target. Defaults to "_blank". Set to a custom value (e.g. "_top")
         or to false to open in the same window.
 */ -}}
-{{- $version := or (.Get 0) (.Get "version") .Page.Params.since -}}
+{{- $version := "" -}}
+{{- with .Page.Params.since }}{{ $version = . }}{{ end -}}
+{{- if .IsNamedParams -}}
+  {{- with .Get "version" }}{{ $version = . }}{{ end -}}
+{{- else -}}
+  {{- with .Get 0 }}{{ $version = . }}{{ end -}}
+{{- end -}}
 {{- with $version -}}
   {{- $repoURL := "" -}}
   {{- $target := "_blank" -}}


### PR DESCRIPTION
## Summary

Migrates the `since` shortcode from the documentation site into the theme itself, so every Ananke site can use it. It renders a small badge marking the release a feature was introduced in (e.g. "since 2.17.0").

## Changes

- **`layouts/_shortcodes/since.html`** — new theme shortcode. The version is resolved, in order of precedence, from:
  - the first positional argument: `{{< since "2.17.0" >}}`
  - a named `version` argument: `{{< since version="2.17.0" >}}`
  - the page's `since` front matter

  When no version can be resolved it renders nothing and prints a build-time `warnf` naming the page.
- **`i18n/en.toml`** — new translatable `since` label.

## Behaviour

- **No link by default.** With no configuration the badge is plain text (`<span>`). Linking is opt-in.
- **`params.ananke.shortcodes.since.repo_url`** — a printf format string (`%s` = version). Setting it turns the badge into an `<a>` linking to that release. Not shipped in the theme's default config (documented only).
- **`params.ananke.shortcodes.since.target`** — link target, defaults to `_blank` (with `rel="noopener"`). Set a custom value (e.g. `"_top"`) or `false` to open in the same window.

## Notes

The accompanying documentation lives in the separate `documentation` repo (a `shortcodes/since` page plus removal of the docs site's local copy, which now resolves from the theme module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)