### PR TITLE
feat: add edit-page shortcode for GitHub edit links

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -34,6 +34,9 @@ other = "An email address is required."
 [send]
 other = "Send"
 
+[editPage]
+other = "Improve this page on GitHub"
+
 [since]
 other = "since"
 

--- a/layouts/_partials/edit-page.html
+++ b/layouts/_partials/edit-page.html
@@ -1,0 +1,61 @@
+{{- /*
+  edit-page partial
+
+  Renders a link to edit the current page's source file on GitHub. Visitors
+  without write access are offered GitHub's standard "fork and propose changes"
+  flow automatically when they follow an /edit/ link, so no extra handling is
+  needed here.
+
+  This partial is the single source of truth shared by the `edit-page`
+  shortcode and by any hook (for example `content-after`) that wants to render
+  the link automatically.
+
+  Accepts either a Page directly, or a map:
+    - page    (required) the Page whose source file should be edited.
+    - branch  (optional) overrides the configured branch for this call.
+
+  Configuration (under params.ananke.shortcodes.edit_page):
+    - repo_url     (required) Base URL of the GitHub repository, e.g.
+                   "https://github.com/owner/repo". When unset nothing renders.
+    - branch       The branch to edit. Defaults to "main".
+    - content_dir  The directory the content lives in inside the repository.
+                   Defaults to "content".
+    - target       Link target. Defaults to "_blank". Set to false to open in
+                   the same window.
+*/ -}}
+{{- $page := . -}}
+{{- $branch := "" -}}
+{{- if reflect.IsMap . -}}
+  {{- $page = .page -}}
+  {{- with .branch }}{{ $branch = . }}{{ end -}}
+{{- end -}}
+{{- $repoURL := "" -}}
+{{- $contentDir := "content" -}}
+{{- $target := "_blank" -}}
+{{- with site.Params.ananke -}}
+  {{- with .shortcodes -}}
+    {{- with .edit_page -}}
+      {{- with .repo_url }}{{ $repoURL = . }}{{ end -}}
+      {{- if not $branch }}{{ $branch = .branch | compare.Default "main" }}{{ end -}}
+      {{- with .content_dir }}{{ $contentDir = . }}{{ end -}}
+      {{- if isset . "target" }}{{ $target = .target }}{{ end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if not $branch }}{{ $branch = "main" }}{{ end -}}
+{{- with $page.File -}}
+  {{- if $repoURL -}}
+    {{- $filePath := strings.Replace .Path "\\" "/" -}}
+    {{- $path := path.Join $contentDir $filePath -}}
+    {{- $url := printf "%s/edit/%s/%s" (strings.TrimSuffix "/" $repoURL) $branch $path -}}
+    {{- $rel := "" -}}
+    {{- if and $target (ne $target "_self") }}{{ $rel = "noopener" }}{{ end -}}
+    <a class="f6 link dim br2 ba bw1 ph3 pv2 mb2 dib navy" href="{{ $url }}"
+      {{- with $target }} target="{{ . }}"{{ end -}}
+      {{- with $rel }} rel="{{ . }}"{{ end }}>
+      {{ T "editPage" }}
+    </a>
+  {{- else -}}
+    {{- warnf "[ananke] the 'edit-page' partial in %q needs params.ananke.shortcodes.edit_page.repo_url to be set" .Path -}}
+  {{- end -}}
+{{- end -}}

--- a/layouts/_shortcodes/edit-page.html
+++ b/layouts/_shortcodes/edit-page.html
@@ -1,0 +1,26 @@
+{{- /*
+  edit-page shortcode
+
+  Renders a link to edit the current page's source file on GitHub. Visitors
+  without write access to the repository are automatically offered GitHub's
+  standard "fork and propose changes" flow when they follow the link.
+
+  The branch can be overridden per call:
+    - positional:  {{< edit-page "development" >}}
+    - named:       {{< edit-page branch="development" >}}
+
+  All other settings are read from site configuration. See the shared
+  `edit-page.html` partial for the full list of configuration options under
+  params.ananke.shortcodes.edit_page.
+*/ -}}
+{{- $branch := "" -}}
+{{- if .IsNamedParams -}}
+  {{- with .Get "branch" }}{{ $branch = . }}{{ end -}}
+{{- else -}}
+  {{- with .Get 0 }}{{ $branch = . }}{{ end -}}
+{{- end -}}
+{{- with .Page.File -}}
+  {{- partials.Include "edit-page.html" (dict "page" $.Page "branch" $branch) -}}
+{{- else -}}
+  {{- warnf "[ananke] the 'edit-page' shortcode was used on a page without a source file (%q)" $.Page.Title -}}
+{{- end -}}


### PR DESCRIPTION
## Summary

Adds a reusable **"Improve this page on GitHub"** edit link, the affordance documentation sites commonly place at the foot of a page.

- **`layouts/_partials/edit-page.html`** — single source of truth. Builds the GitHub edit URL `{repo_url}/edit/{branch}/{content_dir}/{file-path}` and renders a badge-styled link. Reads `params.ananke.shortcodes.edit_page` (`repo_url`, `branch`, `content_dir`, `target`). Accepts a `Page` or a `{page, branch}` map.
- **`layouts/_shortcodes/edit-page.html`** — thin shortcode wrapper following the shortcode style guide (`IsNamedParams`, positional + named `branch` override, warns when used on a page without a source file).
- **`i18n/en.toml`** — new translatable `editPage` string ("Improve this page on GitHub").

## Fork support is automatic

Using GitHub's `/edit/` URL means visitors **without** write access are automatically offered GitHub's built-in "fork and propose changes" flow on save — no extra logic required.

## Usage

```go-html-template
{{</* edit-page */>}}                      {{/* configured branch */>}}
{{</* edit-page "main" */>}}               {{/* positional branch override */>}}
{{</* edit-page branch="development" */>}} {{/* named branch override */>}}
```

The same partial can be rendered automatically below all content via a `content-after` hook (done in the documentation repo).

## Notes

- The `content-after` hook only fires on single pages, so section index (`_index.md`) pages won't show the link unless the hook call is also added to `list.html`/`home.html`.
- Companion documentation PR added in the `documentation` repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)