### PR TITLE
fix: use site regular pages for related content lookup

### DIFF
--- a/layouts/single.html
+++ b/layouts/single.html
@@ -4,7 +4,7 @@
 {{ end }}
 
 {{ define "main" }}
-  {{- $related_content := .RegularPages.Related . -}}
+  {{- $related_content := .Site.RegularPages.Related . -}}
   {{- $needs_aside := or .Params.toc $related_content -}}
   {{ $page := .}}
   {{ $section := .Site.GetPage "section" .Section }}


### PR DESCRIPTION
Closes #1072

This PR fixes an issue where related content is not displayed in the Ananke theme unless `toc` is enabled.

The current template uses:

```go-html-template
{{- $related_content := .RegularPages.Related . -}}
```

This causes the related content lookup to fail in some page contexts, resulting in no related pages being rendered even when related content exists.

This PR changes the lookup to:

```go-html-template
{{- $related_content := .Site.RegularPages.Related . -}}
```

Using `.Site.RegularPages` ensures that related content is searched across all regular pages in the site, restoring the expected related content behavior.

The change is limited to the template lookup scope and does not introduce any new functionality.